### PR TITLE
Throw error when specified method does not exist

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,7 +3,6 @@ RewriteEngine on
 RewriteRule ^([a-z]+)/([a-z]+)/?$ index.php?resource=$1&method=$2 [L,QSA]
 RewriteRule ^([a-z]+)/?$ index.php?resource=$1 [L,QSA]
 
-
 <Files "run">
     Order Allow,Deny
     Deny from all

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,8 @@
 RewriteEngine on
 
-RewriteRule ^([a-z]+)/([a-z]+)$ index.php?resource=$1&method=$2 [L,QSA]
+RewriteRule ^([a-z]+)/([a-z]+)/?$ index.php?resource=$1&method=$2 [L,QSA]
+RewriteRule ^([a-z]+)/?$ index.php?resource=$1 [L,QSA]
+
 
 <Files "run">
     Order Allow,Deny

--- a/controllers/base.php
+++ b/controllers/base.php
@@ -9,8 +9,7 @@
             $resource = basename( $resource );
             $filename = 'controllers/' . $resource . '.php';
             if ( !file_exists( $filename ) ) {
-                $resource = 'dashboard';
-                $filename = 'controllers/' . $resource . '.php';
+                throw new HTTPNotFoundException();
             }
             require_once $filename;
             $controllername = ucfirst( $resource ) . 'Controller';

--- a/index.php
+++ b/index.php
@@ -5,10 +5,10 @@
         $resource = $_GET[ 'resource' ];
     }
     else {
-        $resource = '';
+        $resource = 'dashboard';
     }
-    $controller = controllerBase::findController( $resource );
     try {
+        $controller = controllerBase::findController( $resource );
         $controller->dispatch( $_GET, $_POST, $_FILES, $_SERVER[ 'REQUEST_METHOD' ] );
     }
     catch ( NotImplemented $e ) {


### PR DESCRIPTION
Fixes #247.
I am not sure if the rewrite rule changes are should be included in this pull request.
Please review.

Before only requests in the form `endofcodes.com/recoursce/method` worked.
With the new RewriteRules the following requests are valid:

```
endofcodes.com/recource
endofcodes.com/recource/
endofcodes.com/recource/method
endofcodes.com/recource/method/
```
