### PR TITLE
Error controller to handle HTTP errors.

### DIFF
--- a/controllers/base.php
+++ b/controllers/base.php
@@ -4,7 +4,7 @@
         protected $environment = 'development';
         protected $trusted = false;
         protected $outputFormat = 'html';
-        protected $pageGenerationBegin; // time marking the beginning of page generation, in epoch seconds
+        protected $pageGenerationBegin; // Time marking the beginning of page generation, in epoch seconds.
         protected $method = 'view'; // Override to specify a default controller method.
 
         public static function findController( $resource ) {
@@ -143,12 +143,7 @@
                 dbInit();
             }
             catch ( DBException $e ) {
-                $arguments = get_object_vars( $e );
-                $arguments['method'] = 'create';
-                $controller = controllerBase::findController( 'dbconfig' );
-                $controller->dispatch( $arguments, '', '', 'GET' );
-                exit(0);
-                //go( 'dbconfig', 'create', $arguments );
+                throw new ErrorRedirectException( 'dbconfig', get_object_vars( $e ) );
             }
         }
         private function initDebug() {
@@ -182,6 +177,19 @@
         }
         public function getPageGenerationTime() {
             return microtime( true ) - $this->pageGenerationBegin;
+        }
+    }
+
+    class ErrorRedirectException extends Exception {
+        private $controller;
+        private $arguments;
+        public function __construct( $controller, $arguments ) {
+            $this->controller = $controller;
+            $this->arguments = $arguments;
+        }
+        public function callErrorController() {
+            $controller = controllerBase::findController( $this->controller );
+            $controller->dispatch( $this->arguments, '', '', 'GET' );
         }
     }
 ?>

--- a/controllers/base.php
+++ b/controllers/base.php
@@ -1,11 +1,11 @@
 <?php
     abstract class ControllerBase {
-        protected $acceptTypes = [];
-        protected $environment = 'development';
-        protected $trusted = false;
-        protected $outputFormat = 'html';
-        protected $pageGenerationBegin; // Time marking the beginning of page generation, in epoch seconds.
-        protected $method = 'view'; // Override to specify a default controller method.
+        public $acceptTypes = [];
+        public $environment = 'development';
+        public $trusted = false;
+        public $outputFormat = 'html';
+        public $pageGenerationBegin; // Time marking the beginning of page generation, in epoch seconds.
+        public $method = 'view'; // Override to specify a default controller method.
 
         public static function findController( $resource ) {
             $resource = basename( $resource );

--- a/controllers/base.php
+++ b/controllers/base.php
@@ -1,10 +1,10 @@
 <?php
     abstract class ControllerBase {
         protected $acceptTypes = [];
-        public $environment = 'development';
-        public $trusted = false;
-        public $outputFormat = 'html';
-        public $pageGenerationBegin; // time marking the beginning of page generation, in epoch seconds
+        protected $environment = 'development';
+        protected $trusted = false;
+        protected $outputFormat = 'html';
+        protected $pageGenerationBegin; // time marking the beginning of page generation, in epoch seconds
         protected $method = 'view'; // Override to specify a default controller method.
 
         public static function findController( $resource ) {
@@ -19,7 +19,7 @@
 
             return $controller;
         }
-        protected function sessionCheck() {
+        private function sessionCheck() {
             global $config;
 
             if ( isset( $_SESSION[ 'user' ] ) ) {
@@ -37,7 +37,7 @@
                 $_SESSION[ 'user' ] = $user;
             }
         }
-        protected function getControllerVars( $get, $post, $files, $httpRequestMethod ) {
+        private function getControllerVars( $get, $post, $files, $httpRequestMethod ) {
             switch ( $httpRequestMethod ) {
                 case 'POST':
                     $vars = array_merge( $post, $files );
@@ -52,7 +52,7 @@
 
             return $vars;
         }
-        protected function protectFromForgery( $vars, $httpRequestMethod ) {
+        private function protectFromForgery( $vars, $httpRequestMethod ) {
             if ( $this->trusted ) {
                 return;
             }
@@ -65,7 +65,7 @@
                 }
             }
         }
-        protected function getControllerMethod( $vars, $httpRequestMethod ) {
+        private function getControllerMethod( $vars, $httpRequestMethod ) {
             if ( isset( $vars[ 'method' ] ) ) {
                 $this->method = $vars[ 'method' ];
             }
@@ -80,7 +80,7 @@
             }
             return $this->method;
         }
-        protected function callWithNamedArgs( $method, $vars ) {
+        private function callWithNamedArgs( $method, $vars ) {
             $controllerReflection = new ReflectionObject( $this );
             try {
                 $methodReflection = $controllerReflection->getMethod( $method );
@@ -117,7 +117,7 @@
 
             $config = loadConfig( $this->environment );
         }
-        protected function readHTTPAccept() {
+        private function readHTTPAccept() {
             if ( !isset( $_SERVER[ 'HTTP_ACCEPT' ] ) ) {
                 return;
             }
@@ -151,7 +151,7 @@
                 //go( 'dbconfig', 'create', $arguments );
             }
         }
-        public function initDebug() {
+        private function initDebug() {
             global $debugger;
 
             if ( isset( $_SESSION[ 'debug' ] ) ) {

--- a/controllers/base.php
+++ b/controllers/base.php
@@ -131,7 +131,11 @@
             }
             catch ( DBException $e ) {
                 $arguments = get_object_vars( $e );
-                go( 'dbconfig', 'create', $arguments );
+                $arguments['method'] = 'create';
+                $controller = controllerBase::findController( 'dbconfig' );
+                $controller->dispatch( $arguments, '', '', 'GET' );
+                exit(0);
+                //go( 'dbconfig', 'create', $arguments );
             }
         }
         protected function init() {

--- a/controllers/base.php
+++ b/controllers/base.php
@@ -57,6 +57,9 @@
             }
         }
         private function getControllerVars( $get, $post, $files, $httpRequestMethod ) {
+            if ( isset( $get[ 'method' ] ) ) {
+                $this->method = $get[ 'method' ];
+            }
             $this->httpRequestMethod = $httpRequestMethod;
             $this->vars = [];
             switch ( $this->httpRequestMethod ) {
@@ -65,6 +68,8 @@
                     break;
                 case 'GET':
                     $this->vars = $get;
+                    unset( $this->vars[ 'resource' ] );
+                    unset( $this->vars[ 'method' ] );
                     break;
             }
             $this->protectFromForgery();
@@ -80,9 +85,6 @@
             }
         }
         private function getControllerMethod() {
-            if ( isset( $this->vars[ 'method' ] ) ) {
-                $this->method = $this->vars[ 'method' ];
-            }
             try {
                 if ( Form::getRESTMethodIdempotence( $this->method ) && $this->httpRequestMethod != 'POST' ) {
                     $this->method .= 'View';

--- a/controllers/dbconfig.php
+++ b/controllers/dbconfig.php
@@ -1,5 +1,6 @@
 <?php
     class DbconfigController extends ControllerBase {
+        protected $method = 'create';
         protected function dbInit() {}
 
         public function create( $user, $pass, $dbname ) {

--- a/controllers/httperror.php
+++ b/controllers/httperror.php
@@ -1,5 +1,6 @@
 <?php
     class HTTPErrorController extends ControllerBase {
+      protected $method = 'create';
 
         public function createView( $error, $reason, $header ) {
             header( $header );

--- a/controllers/httperror.php
+++ b/controllers/httperror.php
@@ -1,8 +1,8 @@
 <?php
     class HTTPErrorController extends ControllerBase {
-      public $method = 'create';
+      public $method = 'view';
 
-        public function createView( $error, $reason, $header ) {
+        public function view( $error, $reason, $header ) {
             header( $header );
             require "views/http/$error.php";
         }

--- a/controllers/httperror.php
+++ b/controllers/httperror.php
@@ -1,6 +1,6 @@
 <?php
     class HTTPErrorController extends ControllerBase {
-      protected $method = 'create';
+      public $method = 'create';
 
         public function createView( $error, $reason, $header ) {
             header( $header );

--- a/controllers/httperror.php
+++ b/controllers/httperror.php
@@ -1,0 +1,10 @@
+<?php
+    class HTTPErrorController extends ControllerBase {
+
+        public function createView( $error, $reason, $header ) {
+            header( $header );
+            require "views/http/$error.php";
+        }
+
+    }
+?>

--- a/controllers/httperror.php
+++ b/controllers/httperror.php
@@ -1,11 +1,9 @@
 <?php
     class HTTPErrorController extends ControllerBase {
-      public $method = 'view';
 
         public function view( $error, $reason, $header ) {
             header( $header );
             require "views/http/$error.php";
         }
-
     }
 ?>

--- a/helpers/html.php
+++ b/helpers/html.php
@@ -131,10 +131,10 @@
                 'update' => 1,
                 'view' => 0
             ];
-            if ( isset( $methods[ $method ] ) ) {
-                return $methods[ $method ];
+            if ( !isset( $methods[ $method ] ) ) {
+                throw new HTMLFormInvalidException( $method );
             }
-            throw new HTMLFormInvalidException( $method );
+            return $methods[ $method ];
         }
 
         public function createLabel( $for, $text ) {

--- a/helpers/http.php
+++ b/helpers/http.php
@@ -45,7 +45,7 @@
         }
     }
 
-    class HTTPErrorException extends Exception {
+    class HTTPErrorException extends ErrorRedirectException {
         public $header;
         public $error;
         public $reason;
@@ -59,13 +59,9 @@
             else {
                 $this->header = "HTTP/1.1 $error";
             }
-            parent::__construct( $this->header );
-        }
-        public function outputErrorPage() {
-            header( $e->header );
-            $error = $this->error;
-            $reason = $this->reason;
-            require "views/http/$error.php";
+            $arguments = get_object_vars( $this );
+            parent::__construct( 'httperror', $arguments );
+            // parent::__construct( $this->header );
         }
     }
 

--- a/helpers/http.php
+++ b/helpers/http.php
@@ -64,23 +64,30 @@
         }
     }
 
+    class ErrorRedirectException extends Exception {
+        public $controller;
+        public $arguments;
+        public function __construct( $controller, $arguments ) {
+            $this->controller = $controller;
+            $this->arguments = $arguments;
+            parent::__construct();
+        }
+    }
+
     class HTTPErrorException extends ErrorRedirectException {
         public $header;
         public $error;
         public $reason;
 
-        public function __construct( $error, $description = "", $reason = '' ) {
+        public function __construct( $error, $description = '', $reason = '' ) {
             $this->error = $error;
             $this->reason = $reason;
+            $this->header = "HTTP/1.1 $error";
             if ( !empty( $description ) ) {
-                $this->header = "HTTP/1.1 $error $description";
-            }
-            else {
-                $this->header = "HTTP/1.1 $error";
+                $this->header .= ' ' . $description;
             }
             $arguments = get_object_vars( $this );
             parent::__construct( 'httperror', $arguments );
-            // parent::__construct( $this->header );
         }
     }
 

--- a/helpers/http.php
+++ b/helpers/http.php
@@ -10,6 +10,25 @@
         throw new RedirectException( $resourceOrURL, $method, $args );
     }
 
+    function readHTTPAccept() {
+        if ( !isset( $_SERVER[ 'HTTP_ACCEPT' ] ) ) {
+            return;
+        }
+        $accept = strtolower( str_replace( ' ', '', $_SERVER[ 'HTTP_ACCEPT' ] ) );
+        $accept = explode( ',', $accept );
+        $acceptTypes = [];
+        foreach ( $accept as $a ) {
+            if ( strpos( $a, ';q=' ) ) {
+                list( $a, $q ) = explode( ';q=', $a );
+                if ( $q === 0 ) {
+                    continue;
+                }
+            }
+            $acceptTypes[ $a ] = true;
+        }
+        return $acceptTypes;
+    }
+
     class RedirectException extends Exception {
         private $url;
         public $resource;

--- a/helpers/http.php
+++ b/helpers/http.php
@@ -1,14 +1,4 @@
 <?php
-    /*
-    Redirects to a given URL or resource:
-
-    go( "http://www.google.com" ); // full URL
-    go( "user", "view", [ "example" => "argument" ] ); // resource & method
-    go(); // home page
-    */
-    function go( $resourceOrURL = false, $method = false, $args = [] ) {
-        throw new RedirectException( $resourceOrURL, $method, $args );
-    }
 
     function readHTTPAccept() {
         if ( !isset( $_SERVER[ 'HTTP_ACCEPT' ] ) ) {
@@ -29,15 +19,23 @@
         return $acceptTypes;
     }
 
-    class RedirectException extends Exception {
-        private $url;
+    /*
+    Redirects to a given URL or resource:
+
+    go( "http://www.google.com" ); // full URL
+    go( "user", "view", [ "example" => "argument" ] ); // resource & method
+    go(); // home page
+    */
+    function go( $resourceOrURL = false, $method = false, $args = [] ) {
+        throw new HTTPRedirectException( $resourceOrURL, $method, $args );
+    }
+
+    // This is a simple HTTP Redirect. The web page is reloaded.
+    class HTTPRedirectException extends Exception {
+        public $url;
         public $resource;
         public $method;
         public $args;
-
-        public function getURL() {
-            return $this->url;
-        }
 
         public function __construct( $resourceOrURL = false, $method = false, $args = [] ) {
             if ( $resourceOrURL === false ) {
@@ -64,6 +62,7 @@
         }
     }
 
+    // When this exception is thrown, the controller is changed to a new one, without reloading the page.
     class ErrorRedirectException extends Exception {
         public $controller;
         public $arguments;

--- a/helpers/http.php
+++ b/helpers/http.php
@@ -62,6 +62,7 @@
             parent::__construct( $this->header );
         }
         public function outputErrorPage() {
+            header( $e->header );
             $error = $this->error;
             $reason = $this->reason;
             require "views/http/$error.php";

--- a/index.php
+++ b/index.php
@@ -9,6 +9,12 @@
         catch ( ErrorRedirectException $e ) {
             launchController( $e->controller, $e->arguments );
         }
+        catch ( HTTPRedirectException $e ) {
+            global $config;
+
+            $url = $config[ 'base' ] . $e->url;
+            header( 'Location: ' . $url );
+        }
     }
 
     $resource = 'dashboard';

--- a/index.php
+++ b/index.php
@@ -1,18 +1,20 @@
 <?php
     require_once 'header.php';
 
+    function launchController( $resource, $get, $post = '', $files = '', $httpRequestMethod = 'GET' ) {
+        try {
+            $controller = controllerBase::findController( $resource );
+            $controller->dispatch( $get, $post, $files, $httpRequestMethod );
+        }
+        catch ( ErrorRedirectException $e ) {
+            launchController( $e->controller, $e->arguments );
+        }
+    }
+
     $resource = 'dashboard';
     if ( isset( $_GET[ 'resource' ] ) ) {
         $resource = $_GET[ 'resource' ];
     }
-    try {
-        $controller = controllerBase::findController( $resource );
-        $controller->dispatch( $_GET, $_POST, $_FILES, $_SERVER[ 'REQUEST_METHOD' ] );
-    }
-    catch ( NotImplemented $e ) {
-        die( 'An attempt was made to call a not implemented function: ' . $e->getFunctionName() );
-    }
-    catch ( ErrorRedirectException $e ) {
-        $e->callErrorController(); //should catch exception inside the ControllerBase object.
-    }
+
+    launchController( $resource, $_GET, $_POST, $_FILES, $_SERVER[ 'REQUEST_METHOD' ] );
 ?>

--- a/index.php
+++ b/index.php
@@ -15,14 +15,19 @@
         die( 'An attempt was made to call a not implemented function: ' . $e->getFunctionName() );
     }
     catch ( RedirectException $e ) {
-        global $config;
+        $controller = controllerBase::findController( $resource );
+        $controller->dispatch( $_GET, $_POST, $_FILES, $_SERVER[ 'REQUEST_METHOD' ] );
+        // global $config;
 
-        $url = $e->getURL();
+        // $url = $e->getURL();
 
-        header( 'Location: ' . $config[ 'base' ] . $url );
+        // header( 'Location: ' . $config[ 'base' ] . $url );
     }
     catch ( HTTPErrorException $e ) {
-        header( $e->header );
-        $e->outputErrorPage();
+        // $e->outputErrorPage();
+        $arguments = get_object_vars( $e );
+        $arguments['method'] = 'create';
+        $controller = controllerBase::findController( 'httperror' );
+        $controller->dispatch( $arguments, '', '', 'GET' );
     }
 ?>

--- a/index.php
+++ b/index.php
@@ -14,20 +14,7 @@
     catch ( NotImplemented $e ) {
         die( 'An attempt was made to call a not implemented function: ' . $e->getFunctionName() );
     }
-    catch ( RedirectException $e ) {
-        $controller = controllerBase::findController( $resource );
-        $controller->dispatch( $_GET, $_POST, $_FILES, $_SERVER[ 'REQUEST_METHOD' ] );
-        // global $config;
-
-        // $url = $e->getURL();
-
-        // header( 'Location: ' . $config[ 'base' ] . $url );
-    }
-    catch ( HTTPErrorException $e ) {
-        // $e->outputErrorPage();
-        $arguments = get_object_vars( $e );
-        $arguments['method'] = 'create';
-        $controller = controllerBase::findController( 'httperror' );
-        $controller->dispatch( $arguments, '', '', 'GET' );
+    catch ( ErrorRedirectException $e ) {
+        $e->callErrorController(); //should catch exception inside the ControllerBase object.
     }
 ?>

--- a/index.php
+++ b/index.php
@@ -1,11 +1,9 @@
 <?php
     require_once 'header.php';
 
+    $resource = 'dashboard';
     if ( isset( $_GET[ 'resource' ] ) ) {
         $resource = $_GET[ 'resource' ];
-    }
-    else {
-        $resource = 'dashboard';
     }
     try {
         $controller = controllerBase::findController( $resource );

--- a/models/db.php
+++ b/models/db.php
@@ -2,7 +2,7 @@
     function dbInit() {
         global $config;
 
-        $dbConnected = mysql_connect(
+        $dbConnected = @mysql_connect(
             $config[ 'db' ][ 'host' ],
             $config[ 'db' ][ 'user' ],
             $config[ 'db' ][ 'pass' ]
@@ -11,7 +11,7 @@
             throw new DBException( 'Failed to connect to MySQL.', mysql_error() );
         }
 
-        $dbSelected = mysql_select_db( $config[ 'db' ][ 'dbname' ] );
+        $dbSelected = @mysql_select_db( $config[ 'db' ][ 'dbname' ] );
         if ( !$dbSelected ) {
             throw new DBException( 'Failed to select MySQL database.', mysql_error() );
         }

--- a/run
+++ b/run
@@ -8,23 +8,26 @@
     $_ = array_shift( $argv );
     $resource = array_shift( $argv );
     $method = array_shift( $argv );
-    $controller = controllerBase::findController( $resource );
-    $controller->trusted = true;
-    $controller->outputFormat = 'text';
-
     $vars = [];
     foreach ( $argv as $arg ) {
         list( $key, $value ) = explode( '=', $arg, 2 );
         $vars[ $key ] = $value;
     }
 
-    try {
-        exit( $controller->dispatch( [ 'method' => $method ], $vars, [], 'POST' ) );
+    function launchController( $resource, $get, $post = '', $files = '', $httpRequestMethod = 'GET' ) {
+        try {
+            $controller = controllerBase::findController( $resource );
+            $controller->trusted = true;
+            $controller->outputFormat = 'text';
+            $controller->dispatch( $get, $post, $files, $httpRequestMethod );
+        }
+        catch ( HTTPErrorException $e ) {
+            die( 'An HTTP error occurred: ' . $e->header . ': ' . $e->reason );
+        }
+        catch ( ErrorRedirectException $e ) {
+            launchController( $e->controller, $e->arguments );
+        }
     }
-    catch ( HTTPErrorException $e ) {
-        die( 'An HTTP error occurred: ' . $e->header );
-    }
-    catch ( NotImplemented $e ) {
-        die( 'An attempt was made to call a not implemented function: ' . $e->getFunctionName() . "\n" );
-    }
+
+    exit( launchController( $resource, [ 'method' => $method ], $vars, [], 'POST' ) );
 ?>

--- a/tests/models/file.php
+++ b/tests/models/file.php
@@ -60,6 +60,19 @@
             recursiveCopy( $this->mockPath, $this->copyPath . 'deeper' );
             $this->assertTrue( file_exists( $this->copyPath . 'deeper/' . $path . '/magic.php' ), 'The folder must be copied' );
         }
+        private function safeUnlink( $filename ) {
+            if ( file_exists( $filename ) ) {
+
+                chmod( $filename, 0666 );
+
+                if ( is_dir( $filename ) ) {
+                    rmdir( $filename );
+                }
+                else {
+                    unlink( $filename );
+                }
+            }
+        }
         public function tearDown() {
             $this->safeUnlink( $this->filename );
             $this->safeUnlink( $this->directory );

--- a/tests/models/file.php
+++ b/tests/models/file.php
@@ -60,19 +60,6 @@
             recursiveCopy( $this->mockPath, $this->copyPath . 'deeper' );
             $this->assertTrue( file_exists( $this->copyPath . 'deeper/' . $path . '/magic.php' ), 'The folder must be copied' );
         }
-        private function safeUnlink( $filename ) {
-            if ( file_exists( $filename ) ) {
-
-                chmod( $filename, 0666 );
-
-                if ( is_dir( $filename ) ) {
-                    rmdir( $filename );
-                }
-                else {
-                    unlink( $filename );
-                }
-            }
-        }
         public function tearDown() {
             $this->safeUnlink( $this->filename );
             $this->safeUnlink( $this->directory );


### PR DESCRIPTION
Fixes #310 and #257.

In this pull request:
- I defined a new `ErrorRedirectException` that  can be used instead of `RedirectException` to change the controller withoud reloading the page with an HTTP redirect. 
- I changed the `HTTPErrorException` to extend the new `ErrorRedirextException`. When thrown it changes the controller to the new `HTTPErrorController` as @VitSalis suggested in #257.
- I refactored the `ControllerBase`.
