### PR TITLE
Disable dbconfig in production

### DIFF
--- a/controllers/dbconfig.php
+++ b/controllers/dbconfig.php
@@ -4,6 +4,10 @@
         protected function dbInit() {}
 
         public function create( $user, $pass, $dbname ) {
+            if ( $this->environment == 'production' ) {
+                go(); // disable in production
+            }
+            
             $entries = compact( 'user', 'pass', 'dbname' );
             $entries = [ 'db' => $entries ];
             try {
@@ -17,6 +21,11 @@
         }
         public function createView( $error, $dbSaid ) {
             global $config;
+            
+            if ( $this->environment == 'production' ) {
+                go(); // disable in production
+            }
+            
             $oldConfig = [
                 'db' => [
                     'user'   => '',


### PR DESCRIPTION
The dbconfig controller should not be accessible in production as it exposes the database credentials and allows any user to change them.
